### PR TITLE
Bugfix/env-var

### DIFF
--- a/components/contact.vue
+++ b/components/contact.vue
@@ -117,9 +117,14 @@ export default {
     },
     methods: {
         sendEmail() {
-            const serviceID = 'service_u7fojaf';
-            const templateID = 'template_3fsmp0m';
-            const userID = '0WudSzsNcrhnh8UwS';
+            const config = useRuntimeConfig();
+            const serviceID = config.public.serviceId;
+            const templateID = config.public.templateId;
+            const userID = config.public.userId;
+
+            console.log('Service ID:', serviceID);
+            console.log('Template ID:', templateID);
+            console.log('User ID:', userID);
 
             this.isLoading = true;
 

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -22,16 +22,12 @@ export default defineNuxtConfig({
   },
   compatibilityDate: '2024-04-03',
   devtools: { enabled: true },
-  modules: ['@nuxtjs/tailwindcss', 'shadcn-nuxt', '@nuxtjs/dotenv'],
-  shadcn: {
-    /**
-     * Prefix for all the imported component
-     */
-    prefix: '',
-    /**
-     * Directory that the component lives in.
-     * @default "./components/ui"
-     */
-    componentDir: './components/ui'
+  modules: ['@nuxtjs/tailwindcss'],
+  runtimeConfig: {
+    public: {
+      serviceId: process.env.NUXT_PUBLIC_SERVICE_ID,
+      templateId: process.env.NUXT_PUBLIC_TEMPLATE_ID,
+      userId: process.env.NUXT_PUBLIC_USER_ID
+    }
   }
 })

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -22,7 +22,7 @@ export default defineNuxtConfig({
   },
   compatibilityDate: '2024-04-03',
   devtools: { enabled: true },
-  modules: ['@nuxtjs/tailwindcss', 'shadcn-nuxt'],
+  modules: ['@nuxtjs/tailwindcss', 'shadcn-nuxt', '@nuxtjs/dotenv'],
   shadcn: {
     /**
      * Prefix for all the imported component

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "postinstall": "nuxt prepare"
   },
   "dependencies": {
+    "@nuxtjs/dotenv": "^1.4.2",
     "@vueuse/core": "^11.1.0",
     "@vueuse/head": "^2.0.0",
     "class-variance-authority": "^0.7.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,6 +8,9 @@ importers:
 
   .:
     dependencies:
+      '@nuxtjs/dotenv':
+        specifier: ^1.4.2
+        version: 1.4.2
       '@vueuse/core':
         specifier: ^11.1.0
         version: 11.1.0(vue@3.5.9)
@@ -775,6 +778,9 @@ packages:
     engines: {node: ^14.18.0 || >=16.10.0}
     peerDependencies:
       vue: ^3.3.4
+
+  '@nuxtjs/dotenv@1.4.2':
+    resolution: {integrity: sha512-/3+Cw5qLNIQD8ZvXLJG1suxvfC4ltlUuYegOwirHrLrzptHh/+rCkBXrNbrz2qAiwc+/yK91XjZGGzNM1dFmCw==}
 
   '@nuxtjs/tailwindcss@6.12.1':
     resolution: {integrity: sha512-UKmaPRVpxlFqLorhL6neEba2tySlsj6w6yDb7jzS6A0AAjyBQ6k3BQqWO+AaTy2iQLX7eR+1yj3/w43HzY8RtA==}
@@ -1744,6 +1750,10 @@ packages:
   dotenv@16.4.5:
     resolution: {integrity: sha512-ZmdL2rui+eB2YwhsWzjInR8LldtZHGDoQ1ugH85ppHKwpUHL7j7rN0Ti9NCnGiQbhaZ11FpR+7ao1dNsmduNUg==}
     engines: {node: '>=12'}
+
+  dotenv@8.6.0:
+    resolution: {integrity: sha512-IrPdXQsk2BbzvCBGBOTmmSH5SodmqZNt4ERAZDmW4CT+tL8VtvinqywuANaFu4bOMWki16nqf0e4oC0QIaDr/g==}
+    engines: {node: '>=10'}
 
   duplexer@0.1.2:
     resolution: {integrity: sha512-jtD6YG370ZCIi/9GTaJKQxWTZD045+4R4hTk/x1UyoqadyJ9x9CgSi1RlVDQF8U2sxLLSnFkCaMihqljHIWgMg==}
@@ -4411,6 +4421,11 @@ snapshots:
       - vue-tsc
       - webpack-sources
 
+  '@nuxtjs/dotenv@1.4.2':
+    dependencies:
+      consola: 3.2.3
+      dotenv: 8.6.0
+
   '@nuxtjs/tailwindcss@6.12.1(magicast@0.3.5)(rollup@4.22.4)':
     dependencies:
       '@nuxt/kit': 3.13.2(magicast@0.3.5)(rollup@4.22.4)
@@ -5384,6 +5399,8 @@ snapshots:
       type-fest: 3.13.1
 
   dotenv@16.4.5: {}
+
+  dotenv@8.6.0: {}
 
   duplexer@0.1.2: {}
 


### PR DESCRIPTION
This pull request introduces several changes to the configuration and dependencies of the project, primarily focusing on the integration of environment variables and the removal of an unused module.

### Configuration Changes:

* [`nuxt.config.ts`](diffhunk://#diff-5977891bf10802cdd3cde62f0355105a1662e65b02ae4fb404a27bb0f5f53a07L25-R31): Introduced `runtimeConfig` to manage public environment variables (`serviceId`, `templateId`, `userId`) and removed the `shadcn-nuxt` module.

### Dependency Updates:

* [`package.json`](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519R13): Added `@nuxtjs/dotenv` dependency for handling environment variables.
* [`pnpm-lock.yaml`](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbR11-R13): Updated to include the new `@nuxtjs/dotenv` dependency and its related `dotenv` package. [[1]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbR11-R13) [[2]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbR782-R784) [[3]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbR1754-R1757) [[4]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbR4424-R4428) [[5]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbR5403-R5404)

### Code Changes:

* [`components/contact.vue`](diffhunk://#diff-cf5a12211b774e7fab253ad5a8e57cc65f24155e53a71db93b75749da65b3f4dL120-R127): Updated `sendEmail` method to use environment variables from `runtimeConfig` instead of hardcoded values. Added console logs for debugging.